### PR TITLE
(feat): Support "de-de" if user has "de" in their language list

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+# This workflow will do a clean installation of node dependencies, cache/restore them, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [12.x, 14.x, 16.x]
+        # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node-version }}
+        cache: 'npm'
+    - run: yarn install --frozen-lockfile
+    - run: yarn test

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "browser-lang",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "description": "",
   "repository": "github:wiziple/browser-lang",
@@ -17,7 +17,8 @@
   "main": "./dist/index.js",
   "scripts": {
     "clean": "rimraf dist",
-    "test": "jest test --watch",
+    "test": "jest test",
+    "test:watch": "jest test --watch",
     "build": "babel src --out-dir dist",
     "format": "prettier --write {src,test}/**/*.{js,jsx}"
   },

--- a/src/index.js
+++ b/src/index.js
@@ -57,7 +57,7 @@ function getPreferredLanguage(options) {
 
   // en == en_US
   const matchCodeOnly = languages.filter(lang =>
-    startsWith(browserLanguage, lang)
+    startsWith(browserLanguage, lang) || startsWith(lang, browserLanguage)
   )
   return matchCodeOnly[0] || fallback
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -81,4 +81,24 @@ describe("browserLang", () => {
     }
     expect(browserLang(options)).toBe("zh")
   })
+
+  it('should return "de-de" when navigator.languages is ["de"] and "de-de" is one item in the list.', () => {
+    mockNavigator({
+      languages: ["de"],
+    })
+    const options = {
+      languages: ["en-us", "de-de"],
+    }
+    expect(browserLang(options)).toBe("de-de")
+  })
+
+  it('should return "de-de" when navigator.languages is ["de"] and "de-de" is first item in the list.', () => {
+    mockNavigator({
+      languages: ["de"],
+    })
+    const options = {
+      languages: ["en-us", "de-de", "de-as"],
+    }
+    expect(browserLang(options)).toBe("de-de")
+  })
 })


### PR DESCRIPTION
In the case the user has only a 2 letter string in their browser languages list, but we support only full locales, we will pick the first listed code that matches the first 2 letters.

For example
`de`, [`en-us`, `de-de`, `de-as`] -> `de-de`